### PR TITLE
Fix multi-line for emacs 29

### DIFF
--- a/multi-line-candidate.el
+++ b/multi-line-candidate.el
@@ -22,13 +22,13 @@
 
 ;;; Code:
 
-(require 'eieio)
+(require 'cl-lib)
 
 (defclass multi-line-candidate ()
   ((marker :initarg :marker :initform (point-marker))
    (original-spacing :initarg :original-spacing :initform nil)))
 
-(defmethod multi-line-candidate-position ((candidate multi-line-candidate))
+(cl-defmethod multi-line-candidate-position ((candidate multi-line-candidate))
   (marker-position (oref candidate marker)))
 
 (provide 'multi-line-candidate)

--- a/multi-line-cycle.el
+++ b/multi-line-cycle.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(require 'eieio)
+(require 'cl-lib)
 
 (require 'multi-line-candidate)
 
@@ -38,7 +38,7 @@
    (check-markers :initform t :initarg check-markers)
    (check-last-command :initform nil :initarg check-last-command)))
 
-(defmethod multi-line-respace ((cycler multi-line-cycle-respacer) candidates
+(cl-defmethod multi-line-respace ((cycler multi-line-cycle-respacer) candidates
                                &optional context)
   (let* ((respacer-name (plist-get context :respacer-name))
          (respacer-index (plist-get context :respacer-index))
@@ -56,7 +56,7 @@
       (setq respacer (multi-line-cycle cycler (oref (car candidates) marker))))
     (multi-line-respace respacer candidates context)))
 
-(defmethod multi-line-cycle ((cycler multi-line-cycle-respacer) current-marker)
+(cl-defmethod multi-line-cycle ((cycler multi-line-cycle-respacer) current-marker)
   (if (and (eq multi-line-last-cycler cycler)
            (or (not (oref cycler check-last-command))
                (equal (oref cycler command-at-last-cycle) last-command))
@@ -67,16 +67,16 @@
     (multi-line-cycler-reset cycler current-marker))
   (multi-line-current-respacer cycler))
 
-(defmethod multi-line-current-respacer ((cycler multi-line-cycle-respacer))
+(cl-defmethod multi-line-current-respacer ((cycler multi-line-cycle-respacer))
   (nth (oref cycler cycle-index) (oref cycler respacers)))
 
-(defmethod multi-line-cycler-reset ((cycler multi-line-cycle-respacer) current-marker)
+(cl-defmethod multi-line-cycler-reset ((cycler multi-line-cycle-respacer) current-marker)
   (oset cycler last-cycle-marker current-marker)
   (oset cycler cycle-index 0)
   (oset cycler command-at-last-cycle this-command)
   (setq multi-line-last-cycler cycler))
 
-(defmethod multi-line-increment-cycle-index ((cycler multi-line-cycle-respacer)
+(cl-defmethod multi-line-increment-cycle-index ((cycler multi-line-cycle-respacer)
                                              &optional amount)
   (unless amount (setq amount 1))
   (oset cycler cycle-index

--- a/multi-line-decorator.el
+++ b/multi-line-decorator.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(require 'eieio)
+(require 'cl-lib)
 (require 'shut-up)
 
 (require 'multi-line-candidate)
@@ -49,7 +49,7 @@
   ((respacer :initarg :respacer)
    (decorator :initarg :decorator)))
 
-(defmethod multi-line-respace-one ((decorator multi-line-each-decorator)
+(cl-defmethod multi-line-respace-one ((decorator multi-line-each-decorator)
                                    index candidates)
   (funcall (oref decorator decorator) (oref decorator respacer) index
            candidates))
@@ -107,7 +107,7 @@ appropriately populated by the executor."
 (defclass multi-line-space-restoring-respacer ()
   ((respacer :initarg :respacer)))
 
-(defmethod multi-line-respace-one ((respacer multi-line-space-restoring-respacer)
+(cl-defmethod multi-line-respace-one ((respacer multi-line-space-restoring-respacer)
                                    index candidates)
   (cl-destructuring-bind (startm . endm) (multi-line-space-markers)
     (let* ((start (marker-position startm))

--- a/multi-line-enter.el
+++ b/multi-line-enter.el
@@ -22,13 +22,13 @@
 
 ;;; Code:
 
-(require 'eieio)
+(require 'cl-lib)
 (require 'multi-line-shared)
 
 (defclass multi-line-up-list-enter-strategy ()
   ((skip-chars :initarg :skip-chars :initform nil)))
 
-(defmethod multi-line-enter ((enter multi-line-up-list-enter-strategy)
+(cl-defmethod multi-line-enter ((enter multi-line-up-list-enter-strategy)
                              &optional _context)
   (multi-line-up-list-back)
   (when (oref enter skip-chars)
@@ -39,10 +39,10 @@
 (defclass multi-line-looking-at-enter-strategy ()
   ((enter-regex :initarg :enter-regex :initform "[[:space]]*[{([]")))
 
-(defmethod multi-line-can-enter ((strategy multi-line-looking-at-enter-strategy))
+(cl-defmethod multi-line-can-enter ((strategy multi-line-looking-at-enter-strategy))
   (looking-at (oref strategy enter-regex)))
 
-(defmethod multi-line-enter ((strategy multi-line-looking-at-enter-strategy))
+(cl-defmethod multi-line-enter ((strategy multi-line-looking-at-enter-strategy))
   (re-search-forward (oref strategy enter-regex)))
 
 (provide 'multi-line-enter)

--- a/multi-line-find.el
+++ b/multi-line-find.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(require 'eieio)
+(require 'cl-lib)
 
 (require 'multi-line-candidate)
 (require 'multi-line-enter)
@@ -34,14 +34,14 @@
    (split-advance-fn :initarg :split-advance-fn :initform
                      'multi-line-comma-advance)))
 
-(defmethod multi-line-at-end-of-candidates
+(cl-defmethod multi-line-at-end-of-candidates
   ((strategy multi-line-forward-sexp-find-strategy))
   (or (looking-at (oref strategy done-regex))
       (save-excursion
         ;; Check to see if we get a scan error when trying to move forward
         (condition-case _ignored (forward-sexp) ('scan-error t)))))
 
-(defmethod multi-line-advance
+(cl-defmethod multi-line-advance
   ((strategy multi-line-forward-sexp-find-strategy) &optional _context)
   (cl-loop
    for failed = (condition-case _ignored (forward-sexp)
@@ -52,7 +52,7 @@
               t))
    return nil))
 
-(defmethod multi-line-find ((strategy multi-line-forward-sexp-find-strategy)
+(cl-defmethod multi-line-find ((strategy multi-line-forward-sexp-find-strategy)
                             &optional context)
   (nconc (list (make-instance 'multi-line-candidate))
          (progn
@@ -77,7 +77,7 @@
   ((child :initarg :child)
    (keyword-string :initarg :keyword-string :initform ":")))
 
-(defmethod multi-line-find ((strategy multi-line-keyword-pairing-finder)
+(cl-defmethod multi-line-find ((strategy multi-line-keyword-pairing-finder)
                             &optional context)
   (let ((candidates (multi-line-find (oref strategy child) context))
         last-was-included last-candidate)

--- a/multi-line-respace.el
+++ b/multi-line-respace.el
@@ -24,7 +24,6 @@
 
 (require 'cl-lib)
 (require 'dash)
-(require 'eieio)
 (require 's)
 
 (require 'multi-line-candidate)
@@ -33,7 +32,7 @@
 
 (defclass multi-line-respacer () nil)
 
-(defmethod multi-line-respace ((respacer multi-line-respacer) candidates
+(cl-defmethod multi-line-respace ((respacer multi-line-respacer) candidates
                                &optional _context)
   (cl-loop for candidate being the elements of candidates using (index i) do
            (goto-char (multi-line-candidate-position candidate))
@@ -42,12 +41,12 @@
 (defclass multi-line-space (multi-line-respacer)
   ((spacer :initarg :spacer :initform " ")))
 
-(defmethod multi-line-respace-one ((respacer multi-line-space)
+(cl-defmethod multi-line-respace-one ((respacer multi-line-space)
                                    _index _candidates)
   (when (not (multi-line-spacer-at-point respacer))
     (insert (oref respacer spacer))))
 
-(defmethod multi-line-spacer-at-point ((respacer multi-line-space))
+(cl-defmethod multi-line-spacer-at-point ((respacer multi-line-space))
   ;; TODO/XXX: This would cause problems with a spacer that was more than one
   ;; character long.
   (save-excursion (re-search-backward (format "[^%s]" (oref respacer spacer)))
@@ -56,7 +55,7 @@
 
 (defclass multi-line-always-newline (multi-line-respacer) nil)
 
-(defmethod multi-line-respace-one ((_respacer multi-line-always-newline)
+(cl-defmethod multi-line-respace-one ((_respacer multi-line-always-newline)
                                    _index _candidates)
   (newline-and-indent))
 
@@ -70,27 +69,27 @@
    (first-index :initform 0 :initarg :first-index)
    (final-index :initform -1 :initarg :final-index)))
 
-(defmethod multi-line-should-newline ((respacer multi-line-fill-respacer)
+(cl-defmethod multi-line-should-newline ((respacer multi-line-fill-respacer)
                                       index candidates)
   (let ((candidates-length (length candidates)))
     (when  (<= (multi-line-first-index respacer candidates-length)
                index (multi-line-final-index respacer candidates-length))
       (multi-line-check-fill-column respacer index candidates))))
 
-(defmethod multi-line-first-index ((respacer multi-line-fill-respacer)
+(cl-defmethod multi-line-first-index ((respacer multi-line-fill-respacer)
                                    candidates-length)
   (mod (oref respacer first-index) candidates-length))
 
-(defmethod multi-line-final-index ((respacer multi-line-fill-respacer)
+(cl-defmethod multi-line-final-index ((respacer multi-line-fill-respacer)
                                    candidates-length)
   (mod (oref respacer final-index) candidates-length))
 
-(defmethod multi-line-check-fill-column ((respacer multi-line-fill-respacer)
+(cl-defmethod multi-line-check-fill-column ((respacer multi-line-fill-respacer)
                                          index candidates)
   (> (multi-line-min-max-column-if-no-newline respacer index candidates)
      (multi-line-get-fill-column respacer)))
 
-(defmethod multi-line-min-max-column-if-no-newline
+(cl-defmethod multi-line-min-max-column-if-no-newline
   ((respacer multi-line-fill-respacer) index candidates)
   "Compute the minimum line length of the current expression,
 assuming that no newline is inserted at the current candidate."
@@ -125,7 +124,7 @@ assuming that no newline is inserted at the current candidate."
              (goto-char (multi-line-candidate-position next-candidate))
              (current-column))))))
 
-(defmethod multi-line-respace-one ((respacer multi-line-fill-respacer)
+(cl-defmethod multi-line-respace-one ((respacer multi-line-fill-respacer)
                                    index candidates)
   (let ((selected
          (if (multi-line-should-newline respacer index candidates)
@@ -136,26 +135,26 @@ assuming that no newline is inserted at the current candidate."
 (defclass multi-line-fixed-fill-respacer (multi-line-fill-respacer)
   ((newline-at :initarg :newline-at :initform 80)))
 
-(defmethod multi-line-get-fill-column
+(cl-defmethod multi-line-get-fill-column
   ((respacer multi-line-fixed-fill-respacer))
   (oref respacer newline-at))
 
 (defclass multi-line-fill-column-respacer (multi-line-fill-respacer) nil)
 
-(defmethod multi-line-get-fill-column ((_r multi-line-fill-column-respacer))
+(cl-defmethod multi-line-get-fill-column ((_r multi-line-fill-column-respacer))
   fill-column)
 
 (defclass multi-line-selecting-respacer nil
   ((indices-to-respacer :initarg :indices-to-respacer)
    (default :initarg :default :initform nil)))
 
-(defmethod multi-line-respace-one ((respacer multi-line-selecting-respacer)
+(cl-defmethod multi-line-respace-one ((respacer multi-line-selecting-respacer)
                                    index candidates)
   (let ((selected (multi-line-select-respacer respacer index candidates)))
     (when selected
       (multi-line-respace-one selected index candidates))))
 
-(defmethod multi-line-select-respacer ((respacer multi-line-selecting-respacer)
+(cl-defmethod multi-line-select-respacer ((respacer multi-line-selecting-respacer)
                                        index candidates)
   (cl-loop for (indices . r) in (oref respacer indices-to-respacer)
            when

--- a/multi-line.el
+++ b/multi-line.el
@@ -32,7 +32,6 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'eieio)
 
 (require 'multi-line-cycle)
 (require 'multi-line-decorator)
@@ -94,7 +93,7 @@
    (respace :initarg :respace
             :initform (multi-line-get-default-respacer))))
 
-(defmethod multi-line-candidates ((strategy multi-line-strategy)
+(cl-defmethod multi-line-candidates ((strategy multi-line-strategy)
                                   &optional context)
   "Get the multi-line candidates at point."
   (let ((enter-strategy (oref strategy enter))
@@ -102,7 +101,7 @@
     (multi-line-enter enter-strategy context)
     (multi-line-find find-strategy context)))
 
-(defmethod multi-line-execute ((strategy multi-line-strategy) &optional context)
+(cl-defmethod multi-line-execute ((strategy multi-line-strategy) &optional context)
   (when (or (eq context t) (equal context 'single-line))
     (setq context (plist-put nil :respacer-name :single-line)))
   (save-excursion


### PR DESCRIPTION
Upstream emacs commit https://github.com/emacs-mirror/emacs/commit/d65534d254b3965ea82a9300c12c5c07f88818b7 removes `eieio-compat.el` which means that `mutli-line` is broken as it uses the now-removed `defmethod`. Fix the issue by using `cl-defmethod` from `cl-lib`.