### PR TITLE
fix #18

### DIFF
--- a/multi-line-candidate.el
+++ b/multi-line-candidate.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 
 (defclass multi-line-candidate ()
   ((marker :initarg :marker :initform (point-marker))

--- a/multi-line-cycle.el
+++ b/multi-line-cycle.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 
 (require 'multi-line-candidate)
 

--- a/multi-line-decorator.el
+++ b/multi-line-decorator.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 (require 'shut-up)
 
 (require 'multi-line-candidate)

--- a/multi-line-enter.el
+++ b/multi-line-enter.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 (require 'multi-line-shared)
 
 (defclass multi-line-up-list-enter-strategy ()

--- a/multi-line-find.el
+++ b/multi-line-find.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 
 (require 'multi-line-candidate)
 (require 'multi-line-enter)

--- a/multi-line-respace.el
+++ b/multi-line-respace.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 (require 'dash)
 (require 's)
 

--- a/multi-line-shared.el
+++ b/multi-line-shared.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 (require 'dash)
 (require 's)
 

--- a/multi-line.el
+++ b/multi-line.el
@@ -32,6 +32,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 
 (require 'multi-line-cycle)
 (require 'multi-line-decorator)

--- a/test/multi-line-elisp-test.el
+++ b/test/multi-line-elisp-test.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 
 (require 'multi-line)
 (require 'multi-line-test)

--- a/test/multi-line-python-test.el
+++ b/test/multi-line-python-test.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 (require 'shut-up)
 
 (require 'multi-line)

--- a/test/multi-line-ruby-test.el
+++ b/test/multi-line-ruby-test.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 (require 'shut-up)
 
 (require 'multi-line)

--- a/test/multi-line-test.el
+++ b/test/multi-line-test.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 (require 'ert)
 
 (require 'multi-line)


### PR DESCRIPTION
This pr adds back `(require 'eieio)` in addition to `(require 'cl-lib)` to fix #18 

`eieio` is not deprecated afaik. `cl` is, and replaced by `cl-lib`.  I found at least `defclass` is used in this package and it is defined in `eieio`. Without this `require`, byte compiled of this package will fail to run.

There is a fancy way if we are sure we only use macro from `eieio` like `(eval-when-compile (require 'eieio))` but I chose the safe change instead.